### PR TITLE
WordCram -> WordSkipReason typo

### DIFF
--- a/example/tutorial/K_howDidItGo/K_howDidItGo.pde
+++ b/example/tutorial/K_howDidItGo/K_howDidItGo.pde
@@ -31,7 +31,7 @@ void setup() {
   if (word.wasSkipped()) {
     println(word.word + " was skipped!");
     
-    if (word.wasSkippedBecause() == WordCram.NO_SPACE) {
+    if (word.wasSkippedBecause() == WordSkipReason.NO_SPACE) {
       println(word.word + " was skipped because there was no room");
     }
   }


### PR DESCRIPTION
Hi,
I just spotted a small namespace issue in one example ("how did it go").

best,
Pierre
