### PR TITLE
README.md: Update Wikipedia example to use HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ WordCram](https://github.com/danbernier/WordCram/raw/master/wordcram.png)
 
     // Make a wordcram from a random wikipedia page.
     new WordCram(this)
-      .fromWebPage("http://en.wikipedia.org/wiki/Special:Random")
+      .fromWebPage("https://en.wikipedia.org/wiki/Special:Random")
       .withColors(color(30), color(110),
                   color(random(255), 240, 200))
       .sizedByWeight(5, 120)


### PR DESCRIPTION
Wikipedia recently started forcing HTTPS, and it seems processing
can't handle the HTTP -> HTTPS redirect and spits out an unrelated
error.

Signed-off-by: Alan Orth <alan.orth@gmail.com>