### PR TITLE
Update renderToSvg.pde

### DIFF
--- a/example/OtherExamples/renderToSvg/renderToSvg.pde
+++ b/example/OtherExamples/renderToSvg/renderToSvg.pde
@@ -8,7 +8,7 @@ void setup() {
   Word[] words = new Word[letters.length];
   for (int i = 0; i < letters.length; i++) {
     float weight = map(i, 0, letters.length, 0, 1);
-    words[i] = new Word(letters[i], i);
+    words[i] = new Word(letters[i], weight);
   }
 
   try {


### PR DESCRIPTION
I believe the intention was to use `weight` not `i` to give Word weighting, I know it doesn't seem to matter, but you could use norm instead of map (or simpler not create the weight variable).

PS I have made 2nd release of [ruby_wordcram](https://github.com/ruby-processing/WordCram)